### PR TITLE
Fix app window centering itself between monitors, on systems with 2+ monitors

### DIFF
--- a/application.py
+++ b/application.py
@@ -1418,4 +1418,5 @@ def style_init():
 def launch():
 	style_init()
 	bluclip.update()
+	app.geometry("+0+0")
 	tk.mainloop()


### PR DESCRIPTION
Red line indicates split between monitors.

Before:
![image](https://user-images.githubusercontent.com/49329895/209234489-41077dea-5fcf-49ac-9607-111e54a67afd.png)

After:
![image](https://user-images.githubusercontent.com/49329895/209234603-bebcaca1-bc8a-496f-9ffc-f35779882010.png)

Not the best fix in the world, may look weird on larger screens.